### PR TITLE
Updated Config options

### DIFF
--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -102,7 +102,7 @@
 	      if (params) {
 	        query = "?" + querystring.stringify(params);
 	      }
-	      return _fetch("" + iNaturalistAPI.apiHostProtocol + iNaturalistAPI.apiHost + ("/" + route + "/" + ids.join(",") + query)).then(iNaturalistAPI.thenCheckStatus).then(iNaturalistAPI.thenText).then(iNaturalistAPI.thenJson).then(iNaturalistAPI.thenWrap);
+	      return _fetch("" + iNaturalistAPI.apiURL + ("/" + route + "/" + ids.join(",") + query)).then(iNaturalistAPI.thenCheckStatus).then(iNaturalistAPI.thenText).then(iNaturalistAPI.thenJson).then(iNaturalistAPI.thenWrap);
 	    }
 	  }, {
 	    key: "get",
@@ -113,7 +113,7 @@
 	      }
 	      var apiToken = iNaturalistAPI.apiToken(options);
 	      var headers = apiToken ? { Authorization: apiToken } : {};
-	      return _fetch("" + iNaturalistAPI.apiHostProtocol + iNaturalistAPI.apiHost + ("/" + route + query), { headers: headers }).then(iNaturalistAPI.thenCheckStatus).then(iNaturalistAPI.thenText).then(iNaturalistAPI.thenJson).then(iNaturalistAPI.thenWrap);
+	      return _fetch("" + iNaturalistAPI.apiURL + ("/" + route + query), { headers: headers }).then(iNaturalistAPI.thenCheckStatus).then(iNaturalistAPI.thenText).then(iNaturalistAPI.thenJson).then(iNaturalistAPI.thenWrap);
 	    }
 	  }, {
 	    key: "post",
@@ -207,7 +207,7 @@
 	      if (options.same_origin) {
 	        return "";
 	      }
-	      return "" + iNaturalistAPI.writeHostProtocol + iNaturalistAPI.writeApiHost;
+	      return "" + iNaturalistAPI.writeApiURL;
 	    }
 	  }, {
 	    key: "csrf",
@@ -262,14 +262,10 @@
 	    key: "setConfig",
 	    value: function setConfig(config) {
 	      config = config || {};
-	      var envHostConfig = util.browserMetaTagContent("config:inaturalist_api_host") || util.nodeENV("API_HOST");
-	      var envWriteHostConfig = util.browserMetaTagContent("config:inaturalist_write_api_host") || util.nodeENV("WRITE_API_HOST");
-	      var envApiHostSSL = (util.browserMetaTagContent("config:inaturalist_api_host_ssl") || util.nodeENV("API_HOST_SSL")) === "true";
-	      var envWriteHostSSL = (util.browserMetaTagContent("config:inaturalist_write_host_ssl") || util.nodeENV("WRITE_HOST_SSL")) === "true";
-	      iNaturalistAPI.apiHost = config.apiHost || envHostConfig || "localhost:4000/v1";
-	      iNaturalistAPI.writeApiHost = config.writeApiHost || envWriteHostConfig || "localhost:3000";
-	      iNaturalistAPI.apiHostProtocol = config.apiHostSSL || envApiHostSSL ? "https://" : "http://";
-	      iNaturalistAPI.writeHostProtocol = config.writeHostSSL || envWriteHostSSL ? "https://" : "http://";
+	      var envURLConfig = util.browserMetaTagContent("config:inaturalist_api_url") || util.nodeENV("API_URL");
+	      var envWriteURLConfig = util.browserMetaTagContent("config:inaturalist_write_api_url") || util.nodeENV("WRITE_API_URL");
+	      iNaturalistAPI.apiURL = config.apiURL || envURLConfig || "http://localhost:4000/v1";
+	      iNaturalistAPI.writeApiURL = envWriteURLConfig || envURLConfig || config.writeApiURL || config.apiURL || "http://localhost:3000";
 	    }
 	  }, {
 	    key: "interpolateRouteParams",

--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -262,10 +262,29 @@
 	    key: "setConfig",
 	    value: function setConfig(config) {
 	      config = config || {};
-	      var envURLConfig = util.browserMetaTagContent("config:inaturalist_api_url") || util.nodeENV("API_URL");
-	      var envWriteURLConfig = util.browserMetaTagContent("config:inaturalist_write_api_url") || util.nodeENV("WRITE_API_URL");
+	      var legacyEnv = iNaturalistAPI.legacyEnvConfig(config);
+	      var envURLConfig = legacyEnv.apiURL || util.browserMetaTagContent("config:inaturalist_api_url") || util.nodeENV("API_URL");
+	      var envWriteURLConfig = legacyEnv.writeApiURL || util.browserMetaTagContent("config:inaturalist_write_api_url") || util.nodeENV("WRITE_API_URL");
 	      iNaturalistAPI.apiURL = config.apiURL || envURLConfig || "http://localhost:4000/v1";
 	      iNaturalistAPI.writeApiURL = envWriteURLConfig || envURLConfig || config.writeApiURL || config.apiURL || "http://localhost:3000";
+	    }
+	  }, {
+	    key: "legacyEnvConfig",
+	    value: function legacyEnvConfig(config) {
+	      var oldVariables = {
+	        envHostConfig: config.apiHost || util.browserMetaTagContent("config:inaturalist_api_host") || util.nodeENV("API_HOST"),
+	        envWriteHostConfig: config.writeApiHost || util.browserMetaTagContent("config:inaturalist_write_api_host") || util.nodeENV("WRITE_API_HOST"),
+	        envApiHostSSL: config.apiHostSSL || (util.browserMetaTagContent("config:inaturalist_api_host_ssl") || util.nodeENV("API_HOST_SSL")) === "true",
+	        envWriteHostSSL: config.writeApiHostSSL || (util.browserMetaTagContent("config:inaturalist_write_host_ssl") || util.nodeENV("WRITE_HOST_SSL")) === "true"
+	      };
+	      var updatedVariables = {};
+	      if (oldVariables.envHostConfig) {
+	        updatedVariables.apiURL = (oldVariables.envApiHostSSL ? "https://" : "http://") + oldVariables.envHostConfig;
+	      }
+	      if (oldVariables.envWriteHostConfig) {
+	        updatedVariables.writeApiURL = (oldVariables.envWriteHostSSL ? "https://" : "http://") + oldVariables.envWriteHostConfig;
+	      }
+	      return updatedVariables;
 	    }
 	  }, {
 	    key: "interpolateRouteParams",

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -11,7 +11,7 @@ var iNaturalistAPI = class iNaturalistAPI {
     if( params ) {
       query = `?${ querystring.stringify( params ) }`;
     }
-    return fetch( `${ iNaturalistAPI.apiHostProtocol }${ iNaturalistAPI.apiHost }` +
+    return fetch( `${ iNaturalistAPI.apiURL }` +
                   `/${ route }/${ ids.join(",") }${ query }` ).
       then( iNaturalistAPI.thenCheckStatus ).
       then( iNaturalistAPI.thenText ).
@@ -26,7 +26,7 @@ var iNaturalistAPI = class iNaturalistAPI {
     }
     var apiToken = iNaturalistAPI.apiToken( options );
     var headers = apiToken ? { Authorization: apiToken } : { };
-    return fetch( `${ iNaturalistAPI.apiHostProtocol }${ iNaturalistAPI.apiHost }` +
+    return fetch( `${ iNaturalistAPI.apiURL }` +
                   `/${ route }${ query }`, { headers: headers } ).
       then( iNaturalistAPI.thenCheckStatus ).
       then( iNaturalistAPI.thenText ).
@@ -112,7 +112,7 @@ var iNaturalistAPI = class iNaturalistAPI {
 
   static methodHostPrefix( options ) {
     if( options.same_origin ) { return ""; }
-    return `${ iNaturalistAPI.writeHostProtocol }${ iNaturalistAPI.writeApiHost }`;
+    return `${ iNaturalistAPI.writeApiURL }`;
   }
 
   static csrf( ) {
@@ -156,26 +156,16 @@ var iNaturalistAPI = class iNaturalistAPI {
 
   static setConfig( config ) {
     config = config || { };
-    var envHostConfig =
-      util.browserMetaTagContent( "config:inaturalist_api_host" ) ||
-      util.nodeENV( "API_HOST" );
-    var envWriteHostConfig =
-      util.browserMetaTagContent( "config:inaturalist_write_api_host" ) ||
-      util.nodeENV( "WRITE_API_HOST" );
-    var envApiHostSSL = (
-      util.browserMetaTagContent( "config:inaturalist_api_host_ssl" ) ||
-      util.nodeENV( "API_HOST_SSL" )
-    ) === "true";
-    var envWriteHostSSL = (
-      util.browserMetaTagContent( "config:inaturalist_write_host_ssl" ) ||
-      util.nodeENV( "WRITE_HOST_SSL" )
-    ) === "true";
-    iNaturalistAPI.apiHost =
-      config.apiHost || envHostConfig || "localhost:4000/v1";
-    iNaturalistAPI.writeApiHost =
-      config.writeApiHost || envWriteHostConfig || "localhost:3000";
-    iNaturalistAPI.apiHostProtocol = ( config.apiHostSSL || envApiHostSSL ) ? "https://" : "http://";
-    iNaturalistAPI.writeHostProtocol = ( config.writeHostSSL || envWriteHostSSL ) ? "https://" : "http://";
+    var envURLConfig =
+      util.browserMetaTagContent( "config:inaturalist_api_url" ) ||
+      util.nodeENV( "API_URL" );
+    var envWriteURLConfig =
+      util.browserMetaTagContent( "config:inaturalist_write_api_url" ) ||
+      util.nodeENV( "WRITE_API_URL" );
+    iNaturalistAPI.apiURL =
+      config.apiURL || envURLConfig || "http://localhost:4000/v1";
+    iNaturalistAPI.writeApiURL =
+      envWriteURLConfig || envURLConfig || config.writeApiURL || config.apiURL || "http://localhost:3000";
   }
 
   static interpolateRouteParams( route, params ) {

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -156,16 +156,52 @@ var iNaturalistAPI = class iNaturalistAPI {
 
   static setConfig( config ) {
     config = config || { };
+    var legacyEnv = iNaturalistAPI.legacyEnvConfig( config );
     var envURLConfig =
+      legacyEnv.apiURL ||
       util.browserMetaTagContent( "config:inaturalist_api_url" ) ||
       util.nodeENV( "API_URL" );
     var envWriteURLConfig =
+      legacyEnv.writeApiURL ||
       util.browserMetaTagContent( "config:inaturalist_write_api_url" ) ||
       util.nodeENV( "WRITE_API_URL" );
     iNaturalistAPI.apiURL =
       config.apiURL || envURLConfig || "http://localhost:4000/v1";
     iNaturalistAPI.writeApiURL =
       envWriteURLConfig || envURLConfig || config.writeApiURL || config.apiURL || "http://localhost:3000";
+  }
+
+  static legacyEnvConfig( config ) {
+    var oldVariables = {
+      envHostConfig:
+        config.apiHost ||
+        util.browserMetaTagContent( "config:inaturalist_api_host" ) ||
+        util.nodeENV( "API_HOST" ),
+      envWriteHostConfig:
+        config.writeApiHost ||
+        util.browserMetaTagContent( "config:inaturalist_write_api_host" ) ||
+        util.nodeENV( "WRITE_API_HOST" ),
+      envApiHostSSL: config.apiHostSSL || ( (
+        util.browserMetaTagContent( "config:inaturalist_api_host_ssl" ) ||
+        util.nodeENV( "API_HOST_SSL" )
+      ) === "true" ),
+      envWriteHostSSL: config.writeApiHostSSL || ( (
+        util.browserMetaTagContent( "config:inaturalist_write_host_ssl" ) ||
+        util.nodeENV( "WRITE_HOST_SSL" )
+      ) === "true" )
+    };
+    var updatedVariables = { };
+    if( oldVariables.envHostConfig ) {
+      updatedVariables.apiURL =
+        ( oldVariables.envApiHostSSL ? "https://" : "http://" ) +
+        oldVariables.envHostConfig;
+    }
+    if( oldVariables.envWriteHostConfig ) {
+      updatedVariables.writeApiURL =
+        ( oldVariables.envWriteHostSSL ? "https://" : "http://" ) +
+        oldVariables.envWriteHostConfig;
+    }
+    return updatedVariables;
   }
 
   static interpolateRouteParams( route, params ) {


### PR DESCRIPTION
There are no longer SSL/Host options, rather a URL with embedded protocol that combines them both.

The browser uses headers of `config:inaturalist_api_url` and `config:inaturalist_write_host_ssl`, and node.js can use a config of `config.apiURL` and `config. writeApiURL`, or an ENV variable of `API_URL` or `WRITE_API_URL`. Should be backwards compatible with the old config options