### PR TITLE
Support for some API V2 functionality

### DIFF
--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -1696,12 +1696,24 @@ function () {
   }, {
     key: "vote",
     value: function vote(params, options) {
-      return iNaturalistAPI.post("votes/vote/annotation/:id", params, options).then(Annotation.typifyInstanceResponse);
+      var endpoint = "votes/vote/annotation/:id";
+
+      if (iNaturalistAPI.apiURL && iNaturalistAPI.apiURL.match(/\/v2/)) {
+        endpoint = "annotations/:id/vote";
+      }
+
+      return iNaturalistAPI.post(endpoint, params, options).then(Annotation.typifyInstanceResponse);
     }
   }, {
     key: "unvote",
     value: function unvote(params, options) {
-      return iNaturalistAPI.delete("votes/unvote/annotation/:id", params, options);
+      var endpoint = "votes/unvote/annotation/:id";
+
+      if (iNaturalistAPI.apiURL && iNaturalistAPI.apiURL.match(/\/v2/)) {
+        endpoint = "annotations/:id/unvote";
+      }
+
+      return iNaturalistAPI.delete(endpoint, params, options);
     }
   }]);
 

--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -483,7 +483,7 @@ function () {
       var envURLConfig = legacyEnv.apiURL || util.browserMetaTagContent("config:inaturalist_api_url") || util.nodeENV("API_URL");
       var envWriteURLConfig = legacyEnv.writeApiURL || util.browserMetaTagContent("config:inaturalist_write_api_url") || util.nodeENV("WRITE_API_URL");
       iNaturalistAPI.apiURL = config.apiURL || envURLConfig || "https://api.inaturalist.org/v1";
-      iNaturalistAPI.writeApiURL = envWriteURLConfig || envURLConfig || config.writeApiURL || config.apiURL || "https://www.inaturalist.org";
+      iNaturalistAPI.writeApiURL = config.writeApiURL || envWriteURLConfig || envURLConfig || config.apiURL || "https://www.inaturalist.org";
     }
   }, {
     key: "legacyEnvConfig",
@@ -2454,8 +2454,6 @@ function () {
     // eslint-disable-line camelcase
     value: function for_taxon(params) {
       // eslint-disable-line camelcase
-      console.log("[DEBUG] iNaturalistAPI.apiURL: ", iNaturalistAPI.apiURL);
-
       if (iNaturalistAPI.apiURL && iNaturalistAPI.apiURL.match(/\/v2/)) {
         var taxonIds = params.taxon_id.toString().split(",").join(",");
         var newParams = Object.assign({}, params);

--- a/lib/endpoints/annotations.js
+++ b/lib/endpoints/annotations.js
@@ -12,12 +12,20 @@ const annotations = class annotations {
   }
 
   static vote( params, options ) {
-    return iNaturalistAPI.post( "votes/vote/annotation/:id", params, options )
+    let endpoint = "votes/vote/annotation/:id";
+    if ( iNaturalistAPI.apiURL && iNaturalistAPI.apiURL.match( /\/v2/ ) ) {
+      endpoint = "annotations/:id/vote";
+    }
+    return iNaturalistAPI.post( endpoint, params, options )
       .then( Annotation.typifyInstanceResponse );
   }
 
   static unvote( params, options ) {
-    return iNaturalistAPI.delete( "votes/unvote/annotation/:id", params, options );
+    let endpoint = "votes/unvote/annotation/:id";
+    if ( iNaturalistAPI.apiURL && iNaturalistAPI.apiURL.match( /\/v2/ ) ) {
+      endpoint = "annotations/:id/unvote";
+    }
+    return iNaturalistAPI.delete( endpoint, params, options );
   }
 };
 

--- a/lib/endpoints/controlled_terms.js
+++ b/lib/endpoints/controlled_terms.js
@@ -1,33 +1,31 @@
 const iNaturalistAPI = require( "../inaturalist_api" );
 const ControlledTerm = require( "../models/controlled_term" );
 
+const typifyResponse = response => {
+  const typifiedResponse = ControlledTerm.typifyResultsResponse( response );
+  for ( let i = 0; i < typifiedResponse.results.length; i += 1 ) {
+    if ( typifiedResponse.results[i] && !typifiedResponse.results[i].values ) {
+      typifiedResponse.results[i].values = typifiedResponse.results[i].values.map(
+        v => ( new ControlledTerm( v ) )
+      );
+    }
+  }
+  return typifiedResponse;
+};
+
 const controlledTerms = class controlledTerms { // eslint-disable-line camelcase
   static for_taxon( params ) { // eslint-disable-line camelcase
-    return iNaturalistAPI.get( "controlled_terms/for_taxon", params ).then( response => {
-      const typifiedResponse = ControlledTerm.typifyResultsResponse( response );
-      for ( let i = 0; i < typifiedResponse.results.length; i += 1 ) {
-        if ( typifiedResponse.results[i] && !typifiedResponse.results[i].values ) {
-          typifiedResponse.results[i].values = typifiedResponse.results[i].values.map(
-            v => ( new ControlledTerm( v ) )
-          );
-        }
-      }
-      return typifiedResponse;
-    } );
+    if ( iNaturalistAPI.apiURL && iNaturalistAPI.apiURL.match( /\/v2/ ) ) {
+      const taxonIds = params.taxon_id.toString( ).split( "," ).join( "," );
+      const newParams = Object.assign( {}, params );
+      delete newParams.taxon_id;
+      return iNaturalistAPI.get( `controlled_terms/for_taxon/${taxonIds}`, newParams ).then( typifyResponse );
+    }
+    return iNaturalistAPI.get( "controlled_terms/for_taxon", params ).then( typifyResponse );
   }
 
   static search( params ) {
-    return iNaturalistAPI.get( "controlled_terms", params, { } ).then( response => {
-      const typifiedResponse = ControlledTerm.typifyResultsResponse( response );
-      for ( let i = 0; i < response.results.length; i += 1 ) {
-        if ( typifiedResponse.results[i] && !typifiedResponse.results[i].values ) {
-          typifiedResponse.results[i].values = typifiedResponse.results[i].values.map(
-            v => ( new ControlledTerm( v ) )
-          );
-        }
-      }
-      return typifiedResponse;
-    } );
+    return iNaturalistAPI.get( "controlled_terms", params, { } ).then( typifyResponse );
   }
 };
 

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -264,9 +264,9 @@ const iNaturalistAPI = class iNaturalistAPI {
     iNaturalistAPI.apiURL = config.apiURL
       || envURLConfig
       || "https://api.inaturalist.org/v1";
-    iNaturalistAPI.writeApiURL = envWriteURLConfig
+    iNaturalistAPI.writeApiURL = config.writeApiURL
+      || envWriteURLConfig
       || envURLConfig
-      || config.writeApiURL
       || config.apiURL
       || "https://www.inaturalist.org";
   }

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -25,12 +25,24 @@ const iNaturalistAPI = class iNaturalistAPI {
   static fetch( route, ids, params, options ) {
     let fetchIDs = ids;
     if ( !Array.isArray( fetchIDs ) ) { fetchIDs = [fetchIDs]; }
-    let query = "";
-    if ( params ) {
-      query = `?${querystring.stringify( params )}`;
-    }
     const apiToken = iNaturalistAPI.apiToken( options );
     const headers = apiToken ? { Authorization: apiToken } : { };
+    if ( params && params.fields && typeof ( params.fields ) === "object" ) {
+      headers.Accept = "application/json";
+      headers["X-HTTP-Method-Override"] = "GET";
+      return localFetch(
+        `${iNaturalistAPI.apiURL}/${route}/${fetchIDs.join( "," )}`,
+        {
+          method: "post",
+          headers,
+          body: JSON.stringify( params )
+        }
+      )
+        .then( iNaturalistAPI.thenText )
+        .then( iNaturalistAPI.thenJson )
+        .then( iNaturalistAPI.thenWrap );
+    }
+    const query = params ? `?${querystring.stringify( params )}` : "";
     return localFetch( `${iNaturalistAPI.apiURL}`
         + `/${route}/${fetchIDs.join( "," )}${query}`, { headers } )
       .then( iNaturalistAPI.thenText )
@@ -61,6 +73,18 @@ const iNaturalistAPI = class iNaturalistAPI {
       && Object.keys( interpolated.remainingParams ).length > 0
     ) {
       url += `?${querystring.stringify( interpolated.remainingParams )}`;
+    }
+    if ( params && params.fields && typeof ( params.fields ) === "object" ) {
+      headers["X-HTTP-Method-Override"] = "GET";
+      headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS, PUT, DELETE, HEAD";
+      return localFetch( url, {
+        method: "post",
+        headers,
+        body: JSON.stringify( params )
+      } )
+        .then( iNaturalistAPI.thenText )
+        .then( iNaturalistAPI.thenJson )
+        .then( iNaturalistAPI.thenWrap );
     }
     return localFetch( url, { headers } )
       .then( iNaturalistAPI.thenText )


### PR DESCRIPTION
Specifically, if a `fields` param is specified, it will make a POST request with the `X-HTTP-Method-Override` header. Also modified some endpoints to work with the slightly altered equivalents in API v2