### PR TITLE
Endpoints - Adding ability to pass OAuth token via params, where missing

### DIFF
--- a/lib/endpoints/authorized_applications.js
+++ b/lib/endpoints/authorized_applications.js
@@ -2,8 +2,8 @@ const iNaturalistAPI = require( "../inaturalist_api" );
 const AuthorizedApplication = require( "../models/authorized_application" );
 
 const authorizedApplications = class authorizedApplications {
-  static search( params ) {
-    return iNaturalistAPI.get( "authorized_applications", params, { useAuth: true } )
+  static search( params, opts = { } ) {
+    return iNaturalistAPI.get( "authorized_applications", params, { ...opts, useAuth: true } )
       .then( AuthorizedApplication.typifyResultsResponse );
   }
 

--- a/lib/endpoints/observations.js
+++ b/lib/endpoints/observations.js
@@ -80,8 +80,8 @@ const observations = class observations {
       .then( Observation.typifyResultsResponse );
   }
 
-  static search( params ) {
-    return iNaturalistAPI.get( "observations", params, { useAuth: true } )
+  static search( params, opts = { } ) {
+    return iNaturalistAPI.get( "observations", params, { ...opts, useAuth: true } )
       .then( Observation.typifyResultsResponse );
   }
 
@@ -109,8 +109,8 @@ const observations = class observations {
       } );
   }
 
-  static speciesCounts( params ) {
-    return iNaturalistAPI.get( "observations/species_counts", params, { useAuth: true } )
+  static speciesCounts( params, opts = { } ) {
+    return iNaturalistAPI.get( "observations/species_counts", params, { ...opts, useAuth: true } )
       .then( response => {
         if ( response.results ) {
           response.results = response.results.map( r => (
@@ -121,8 +121,8 @@ const observations = class observations {
       } );
   }
 
-  static iconicTaxaCounts( params ) {
-    return iNaturalistAPI.get( "observations/iconic_taxa_counts", params, { useAuth: true } )
+  static iconicTaxaCounts( params, opts = { } ) {
+    return iNaturalistAPI.get( "observations/iconic_taxa_counts", params, { ...opts, useAuth: true } )
       .then( response => {
         if ( response.results ) {
           response.results = response.results.map( r => (
@@ -133,8 +133,8 @@ const observations = class observations {
       } );
   }
 
-  static iconicTaxaSpeciesCounts( params ) {
-    return iNaturalistAPI.get( "observations/iconic_taxa_species_counts", params, { useAuth: true } )
+  static iconicTaxaSpeciesCounts( params, opts = { } ) {
+    return iNaturalistAPI.get( "observations/iconic_taxa_species_counts", params, { ...opts, useAuth: true } )
       .then( response => {
         if ( response.results ) {
           response.results = response.results.map( r => (

--- a/lib/endpoints/provider_authorizations.js
+++ b/lib/endpoints/provider_authorizations.js
@@ -2,8 +2,8 @@ const iNaturalistAPI = require( "../inaturalist_api" );
 const ProviderAuthorization = require( "../models/provider_authorization" );
 
 const ProviderAuthorizations = class ProviderAuthorizations {
-  static search( params ) {
-    return iNaturalistAPI.get( "provider_authorizations", params, { useAuth: true } )
+  static search( params, opts = { } ) {
+    return iNaturalistAPI.get( "provider_authorizations", params, { ...opts, useAuth: true } )
       .then( ProviderAuthorization.typifyResultsResponse );
   }
 

--- a/lib/endpoints/taxa.js
+++ b/lib/endpoints/taxa.js
@@ -12,13 +12,13 @@ const taxa = class taxa {
       .then( Taxon.typifyResultsResponse );
   }
 
-  static autocomplete( params ) {
-    return iNaturalistAPI.get( "taxa/autocomplete", params, { useAuth: true } )
+  static autocomplete( params, opts = { } ) {
+    return iNaturalistAPI.get( "taxa/autocomplete", params, { ...opts, useAuth: true } )
       .then( Taxon.typifyResultsResponse );
   }
 
-  static suggest( params ) {
-    return iNaturalistAPI.get( "taxa/suggest", params, { useAuth: true } ).then( response => {
+  static suggest( params, opts = { } ) {
+    return iNaturalistAPI.get( "taxa/suggest", params, { ...opts, useAuth: true } ).then( response => {
       response.results = response.results.map( r => (
         Object.assign( { }, r, { taxon: new Taxon( r.taxon ) } )
       ) );
@@ -26,13 +26,13 @@ const taxa = class taxa {
     } );
   }
 
-  static lifelist_metadata( params ) { // eslint-disable-line camelcase
-    return iNaturalistAPI.get( "taxa/lifelist_metadata", params, { useAuth: true } )
+  static lifelist_metadata( params, opts = { } ) { // eslint-disable-line camelcase
+    return iNaturalistAPI.get( "taxa/lifelist_metadata", params, { ...opts, useAuth: true } )
       .then( Taxon.typifyResultsResponse );
   }
 
-  static wanted( params ) {
-    return iNaturalistAPI.get( "taxa/:id/wanted", params, { useAuth: true } )
+  static wanted( params, opts = { } ) {
+    return iNaturalistAPI.get( "taxa/:id/wanted", params, { ...opts, useAuth: true } )
       .then( response => Taxon.typifyResultsResponse( response ) );
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inaturalistjs",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "inaturalistjs",
   "author": "iNaturalist",
   "license": "MIT",


### PR DESCRIPTION
Some endpoints were missing a way to pass the OAuth token to them via params