### PR TITLE
Abort signals

### DIFF
--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -132,11 +132,13 @@ var iNaturalistAPI = /*#__PURE__*/function () {
           headers: headers,
           body: JSON.stringify(_objectSpread(_objectSpread({}, params), {}, {
             fields: fieldsObject
-          }))
+          })),
+          signal: options.signal
         });
       } else {
         fetch = localFetch(urlWithQueryParams, {
-          headers: headers
+          headers: headers,
+          signal: options.signal
         });
       }
       return fetch.then(iNaturalistAPI.thenText).then(iNaturalistAPI.thenJson).then(iNaturalistAPI.thenWrap);
@@ -191,11 +193,13 @@ var iNaturalistAPI = /*#__PURE__*/function () {
           headers: headers,
           body: JSON.stringify(_objectSpread(_objectSpread({}, remainingParams), {}, {
             fields: fieldsObject
-          }))
+          })),
+          signal: options.signal
         });
       } else {
         fetch = localFetch(urlWithQueryParams, {
-          headers: headers
+          headers: headers,
+          signal: options.signal
         });
       }
       return fetch.then(iNaturalistAPI.thenText).then(iNaturalistAPI.thenJson).then(iNaturalistAPI.thenWrap);
@@ -265,7 +269,8 @@ var iNaturalistAPI = /*#__PURE__*/function () {
       var fetchOpts = {
         method: options.method || "post",
         credentials: options.same_origin ? "same-origin" : undefined,
-        headers: headers
+        headers: headers,
+        signal: options.signal
       };
       if (options.method !== "head") {
         fetchOpts.body = body;

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -53,10 +53,11 @@ const iNaturalistAPI = class iNaturalistAPI {
       fetch = localFetch( baseURL, {
         method: "post",
         headers,
-        body: JSON.stringify( { ...params, fields: fieldsObject } )
+        body: JSON.stringify( { ...params, fields: fieldsObject } ),
+        signal: options.signal
       } );
     } else {
-      fetch = localFetch( urlWithQueryParams, { headers } );
+      fetch = localFetch( urlWithQueryParams, { headers, signal: options.signal } );
     }
     return fetch
       .then( iNaturalistAPI.thenText )
@@ -111,10 +112,11 @@ const iNaturalistAPI = class iNaturalistAPI {
       fetch = localFetch( baseURL, {
         method: "post",
         headers,
-        body: JSON.stringify( { ...remainingParams, fields: fieldsObject } )
+        body: JSON.stringify( { ...remainingParams, fields: fieldsObject } ),
+        signal: options.signal
       } );
     } else {
-      fetch = localFetch( urlWithQueryParams, { headers } );
+      fetch = localFetch( urlWithQueryParams, { headers, signal: options.signal } );
     }
     return fetch
       .then( iNaturalistAPI.thenText )
@@ -184,7 +186,8 @@ const iNaturalistAPI = class iNaturalistAPI {
     const fetchOpts = {
       method: ( options.method || "post" ),
       credentials: ( options.same_origin ? "same-origin" : undefined ),
-      headers
+      headers,
+      signal: options.signal
     };
     if ( options.method !== "head" ) {
       fetchOpts.body = body;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inaturalistjs",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inaturalistjs",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inaturalistjs",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "inaturalistjs",
   "author": "iNaturalist",
   "license": "MIT",


### PR DESCRIPTION
Allow clients to pass in an [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), so fetch requests can be aborted.