### PR TITLE
refactor: hit Rails API with announcements.search

### DIFF
--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -1996,9 +1996,11 @@ var announcements = /*#__PURE__*/function () {
   return _createClass(announcements, null, [{
     key: "search",
     value: function search(params, options) {
-      return iNaturalistAPI.get("announcements", params, _objectSpread(_objectSpread({}, options), {}, {
+      var opts = _objectSpread(_objectSpread({}, options), {}, {
+        useWriteApi: true,
         useAuth: true
-      })).then(Announcement.typifyInstanceResponse);
+      });
+      return iNaturalistAPI.get("announcements/active", params, opts).then(Announcement.typifyResultsResponse);
     }
   }, {
     key: "dismiss",

--- a/lib/endpoints/announcements.js
+++ b/lib/endpoints/announcements.js
@@ -3,8 +3,13 @@ const Announcement = require( "../models/announcement" );
 
 const announcements = class announcements {
   static search( params, options ) {
-    return iNaturalistAPI.get( "announcements", params, { ...options, useAuth: true } )
-      .then( Announcement.typifyInstanceResponse );
+    const opts = {
+      ...options,
+      useWriteApi: true,
+      useAuth: true
+    };
+    return iNaturalistAPI.get( "announcements/active", params, opts )
+      .then( Announcement.typifyResultsResponse );
   }
 
   static dismiss( params, options ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inaturalistjs",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "inaturalistjs",
   "author": "iNaturalist",
   "license": "MIT",

--- a/test/endpoints/announcements.js
+++ b/test/endpoints/announcements.js
@@ -5,8 +5,8 @@ const announcements = require( "../../lib/endpoints/announcements" );
 describe( "Announcements", ( ) => {
   describe( "search", ( ) => {
     it( "fetches announcements", done => {
-      nock( "http://localhost:4000" )
-        .get( "/v1/announcements" )
+      nock( "http://localhost:3000" )
+        .get( "/announcements/active" )
         .reply( 200, [{ id: 1, body: "test announcement" }] );
       announcements.search( ).then( results => {
         expect( results[0].id ).to.eq( 1 );


### PR DESCRIPTION
As a part of WEB-622 I'm consolidating announcement targeting logic in the Rails app, so inatjs.announcements.search needs to send its requests there instead the node app.