### PR TITLE
web 1059 iconic taxa observation counts endpoint

### DIFF
--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -3774,20 +3774,15 @@ var observations = /*#__PURE__*/function () {
     key: "iconicTaxaCounts",
     value: function iconicTaxaCounts(params) {
       var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      // the v2 API returns a null taxon for the count of observations without
-      // an iconic taxon, equivalent to filtering with iconic_taxa=unknown
-      var unknownTaxon = {
-        id: null,
-        name: "Unknown",
-        iconic_taxon_name: "Unknown"
-      };
       return iNaturalistAPI.get("observations/iconic_taxa_counts", params, _objectSpread(_objectSpread({}, opts), {}, {
         useAuth: true
       })).then(function (response) {
         if (response.results) {
+          // the v2 API returns a null taxon for the count of observations without
+          // an iconic taxon, equivalent to filtering with iconic_taxa=unknown
           response.results = response.results.map(function (r) {
             return _objectSpread(_objectSpread({}, r), {}, {
-              taxon: new Taxon(r.taxon || unknownTaxon)
+              taxon: r.taxon ? new Taxon(r.taxon) : null
             });
           });
         }

--- a/build/inaturalistjs.js
+++ b/build/inaturalistjs.js
@@ -3774,13 +3774,20 @@ var observations = /*#__PURE__*/function () {
     key: "iconicTaxaCounts",
     value: function iconicTaxaCounts(params) {
       var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      // the v2 API returns a null taxon for the count of observations without
+      // an iconic taxon, equivalent to filtering with iconic_taxa=unknown
+      var unknownTaxon = {
+        id: null,
+        name: "Unknown",
+        iconic_taxon_name: "Unknown"
+      };
       return iNaturalistAPI.get("observations/iconic_taxa_counts", params, _objectSpread(_objectSpread({}, opts), {}, {
         useAuth: true
       })).then(function (response) {
         if (response.results) {
           response.results = response.results.map(function (r) {
             return _objectSpread(_objectSpread({}, r), {}, {
-              taxon: new Taxon(r.taxon)
+              taxon: new Taxon(r.taxon || unknownTaxon)
             });
           });
         }

--- a/lib/endpoints/observations.js
+++ b/lib/endpoints/observations.js
@@ -126,14 +126,13 @@ const observations = class observations {
   }
 
   static iconicTaxaCounts( params, opts = { } ) {
-    // the v2 API returns a null taxon for the count of observations without
-    // an iconic taxon, equivalent to filtering with iconic_taxa=unknown
-    const unknownTaxon = { id: null, name: "Unknown", iconic_taxon_name: "Unknown" };
     return iNaturalistAPI.get( "observations/iconic_taxa_counts", params, { ...opts, useAuth: true } )
       .then( response => {
         if ( response.results ) {
+          // the v2 API returns a null taxon for the count of observations without
+          // an iconic taxon, equivalent to filtering with iconic_taxa=unknown
           response.results = response.results.map( r => (
-            { ...r, taxon: new Taxon( r.taxon || unknownTaxon ) }
+            { ...r, taxon: r.taxon ? new Taxon( r.taxon ) : null }
           ) );
         }
         return response;

--- a/lib/endpoints/observations.js
+++ b/lib/endpoints/observations.js
@@ -126,11 +126,14 @@ const observations = class observations {
   }
 
   static iconicTaxaCounts( params, opts = { } ) {
+    // the v2 API returns a null taxon for the count of observations without
+    // an iconic taxon, equivalent to filtering with iconic_taxa=unknown
+    const unknownTaxon = { id: null, name: "Unknown", iconic_taxon_name: "Unknown" };
     return iNaturalistAPI.get( "observations/iconic_taxa_counts", params, { ...opts, useAuth: true } )
       .then( response => {
         if ( response.results ) {
           response.results = response.results.map( r => (
-            { ...r, taxon: new Taxon( r.taxon ) }
+            { ...r, taxon: new Taxon( r.taxon || unknownTaxon ) }
           ) );
         }
         return response;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inaturalistjs",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inaturalistjs",
-      "version": "2.20.0",
+      "version": "2.20.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inaturalistjs",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "inaturalistjs",
   "author": "iNaturalist",
   "license": "MIT",

--- a/test/endpoints/observations.js
+++ b/test/endpoints/observations.js
@@ -316,28 +316,32 @@ describe( "Observation", ( ) => {
       } );
     } );
 
-    it( "returns an Unknown taxon for the null taxon of the unknown bucket", done => {
-      nock( "http://localhost:4000" )
-        .get( "/v1/observations/iconic_taxa_counts" )
-        .reply( 200, uri => {
-          const r = Object.assign( testHelper.mockResponse( uri ), {
-            results: [
-              { count: 2, taxon: { id: 1 } },
-              { count: 1, taxon: null }
-            ]
+    describe( "v2", ( ) => {
+      beforeEach( testHelper.v1ToV2 );
+      afterEach( testHelper.v2ToV1 );
+      it( "returns taxon counts including an Unknown taxon for the null taxon bucket", done => {
+        nock( "http://localhost:4000" )
+          .get( "/v2/observations/iconic_taxa_counts" )
+          .reply( 200, uri => {
+            const r = Object.assign( testHelper.mockResponse( uri ), {
+              results: [
+                { count: 2, taxon: { id: 1 } },
+                { count: 1, taxon: null }
+              ]
+            } );
+            return r;
           } );
-          return r;
+        observations.iconicTaxaCounts( ).then( r => {
+          expect( r.results[0].taxon.constructor.name ).to.eq( "Taxon" );
+          expect( r.results[0].taxon.id ).to.eq( 1 );
+          const unknown = r.results[1].taxon;
+          expect( unknown.constructor.name ).to.eq( "Taxon" );
+          expect( unknown.id ).to.eq( null );
+          expect( unknown.name ).to.eq( "Unknown" );
+          expect( unknown.iconic_taxon_name ).to.eq( "Unknown" );
+          expect( unknown.iconicTaxonName( ) ).to.eq( "Unknown" );
+          done( );
         } );
-      observations.iconicTaxaCounts( ).then( r => {
-        expect( r.results[0].taxon.constructor.name ).to.eq( "Taxon" );
-        expect( r.results[0].taxon.id ).to.eq( 1 );
-        const unknown = r.results[1].taxon;
-        expect( unknown.constructor.name ).to.eq( "Taxon" );
-        expect( unknown.id ).to.eq( null );
-        expect( unknown.name ).to.eq( "Unknown" );
-        expect( unknown.iconic_taxon_name ).to.eq( "Unknown" );
-        expect( unknown.iconicTaxonName( ) ).to.eq( "Unknown" );
-        done( );
       } );
     } );
   } );

--- a/test/endpoints/observations.js
+++ b/test/endpoints/observations.js
@@ -319,7 +319,7 @@ describe( "Observation", ( ) => {
     describe( "v2", ( ) => {
       beforeEach( testHelper.v1ToV2 );
       afterEach( testHelper.v2ToV1 );
-      it( "returns taxon counts including an Unknown taxon for the null taxon bucket", done => {
+      it( "returns taxon counts including a null taxon for the unknown bucket", done => {
         nock( "http://localhost:4000" )
           .get( "/v2/observations/iconic_taxa_counts" )
           .reply( 200, uri => {
@@ -334,12 +334,8 @@ describe( "Observation", ( ) => {
         observations.iconicTaxaCounts( ).then( r => {
           expect( r.results[0].taxon.constructor.name ).to.eq( "Taxon" );
           expect( r.results[0].taxon.id ).to.eq( 1 );
-          const unknown = r.results[1].taxon;
-          expect( unknown.constructor.name ).to.eq( "Taxon" );
-          expect( unknown.id ).to.eq( null );
-          expect( unknown.name ).to.eq( "Unknown" );
-          expect( unknown.iconic_taxon_name ).to.eq( "Unknown" );
-          expect( unknown.iconicTaxonName( ) ).to.eq( "Unknown" );
+          expect( r.results[1].taxon ).to.eq( null );
+          expect( r.results[1].count ).to.eq( 1 );
           done( );
         } );
       } );

--- a/test/endpoints/observations.js
+++ b/test/endpoints/observations.js
@@ -315,6 +315,31 @@ describe( "Observation", ( ) => {
         done( );
       } );
     } );
+
+    it( "returns an Unknown taxon for the null taxon of the unknown bucket", done => {
+      nock( "http://localhost:4000" )
+        .get( "/v1/observations/iconic_taxa_counts" )
+        .reply( 200, uri => {
+          const r = Object.assign( testHelper.mockResponse( uri ), {
+            results: [
+              { count: 2, taxon: { id: 1 } },
+              { count: 1, taxon: null }
+            ]
+          } );
+          return r;
+        } );
+      observations.iconicTaxaCounts( ).then( r => {
+        expect( r.results[0].taxon.constructor.name ).to.eq( "Taxon" );
+        expect( r.results[0].taxon.id ).to.eq( 1 );
+        const unknown = r.results[1].taxon;
+        expect( unknown.constructor.name ).to.eq( "Taxon" );
+        expect( unknown.id ).to.eq( null );
+        expect( unknown.name ).to.eq( "Unknown" );
+        expect( unknown.iconic_taxon_name ).to.eq( "Unknown" );
+        expect( unknown.iconicTaxonName( ) ).to.eq( "Unknown" );
+        done( );
+      } );
+    } );
   } );
 
   describe( "iconicTaxaSpeciesCounts", ( ) => {


### PR DESCRIPTION
Update the js client to provide a Taxon object for Unknown taxon in taxa_observation_counts.

Related to https://github.com/inaturalist/iNaturalistAPI/pull/645/